### PR TITLE
Specify process group for child processes

### DIFF
--- a/src/commands/config/apply.rs
+++ b/src/commands/config/apply.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashMap,
     fs,
     io::Write,
+    os::unix::process::CommandExt,
     path::Path,
     process::{Command, Stdio},
 };
@@ -36,6 +37,7 @@ fn apply_service_config(
             )
             .stdout(Stdio::null())
             .stdin(Stdio::piped())
+            .process_group(0)
             .spawn()
             .context("failed to run picodata admin")?;
 

--- a/src/commands/lib.rs
+++ b/src/commands/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use std::io::{BufRead, BufReader, Read};
+use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 
 pub enum BuildType {
@@ -17,6 +18,7 @@ pub fn cargo_build(build_type: BuildType) -> Result<()> {
     let mut child = Command::new("cargo")
         .args(args)
         .stdout(Stdio::piped())
+        .process_group(0)
         .spawn()
         .context("running cargo build")?;
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -2,6 +2,7 @@ use constcat::concat;
 use log::info;
 use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Write};
+use std::os::unix::process::CommandExt;
 use std::thread;
 use std::{
     fs::{self},
@@ -131,6 +132,7 @@ where
         .arg("pike")
         .args(args)
         .current_dir(current_dir)
+        .process_group(0)
         .spawn()
 }
 
@@ -168,6 +170,7 @@ pub fn await_picodata_admin(timeout: Duration) -> Result<Child, std::io::Error> 
             .arg(PLUGIN_DIR.to_string() + "tmp/cluster/i_1/admin.sock")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
+            .process_group(0)
             .spawn();
 
         match picodata_admin {


### PR DESCRIPTION
To properly close all child processes, they should have the same process group with parent

Closes #20 , #16 