### PR TITLE
feat: expose PicodataInstance object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cluster {
     pub use crate::commands::run::ParamsBuilder as RunParamsBuilder;
 
     pub use crate::commands::run::MigrationContextVar;
+    pub use crate::commands::run::PicodataInstance;
     pub use crate::commands::run::Plugin;
     pub use crate::commands::run::Service;
     pub use crate::commands::run::Tier;


### PR DESCRIPTION
Публичный API `pike::cluster::run(...)` возвращает `Vec<PicodataInstance>`. Чтобы можно было использовать PicodataInstance его нужно сделать публичным в lib.rs наряду с cluster::run функцией.