### PR TITLE
sort migration files when adding them to manifest.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Sort migration files, before inserting into `manifest.yaml` (fc01dca)
+
 ## [2.0.2]
 
 ### Changed

--- a/src/helpers/build/mod.rs
+++ b/src/helpers/build/mod.rs
@@ -89,7 +89,7 @@ pub fn main(params: &Params) {
     let crate_dir = Path::new(&crate_dir);
 
     let migrations_dir = crate_dir.join("migrations");
-    let migrations: Vec<String> = fs::read_dir(&migrations_dir)
+    let mut migrations: Vec<String> = fs::read_dir(&migrations_dir)
         .map(|dir| {
             dir.map(|p| {
                 p.unwrap()
@@ -102,6 +102,8 @@ pub fn main(params: &Params) {
             .collect()
         })
         .unwrap_or_default();
+
+    migrations.sort();
 
     // Copy migrations directory and manifest into newest plugin version
     if !migrations.is_empty() {


### PR DESCRIPTION
При вызове миграционных файлов, пикодата ожидает их в отсортированном виде, а пайк не сортирует их, в этом МРе это исправлено