### PR TITLE
Добавление возможности копировать файлы/папки в ассеты с новым путем

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## Unreleased
+
+### Added
+
+- Support adding assets under custom names (4b7a9e9)
+
+
 ## [2.1.2]
 
 ### Fixed

--- a/tests/assets/custom_assets_named_build.rs
+++ b/tests/assets/custom_assets_named_build.rs
@@ -1,0 +1,20 @@
+use pike::helpers::build;
+
+// Custom build script for plugin, which stores
+// plugin's artefacts in corresponding folder
+//
+// Call of build::main() function is MANDATORY
+// for proper artefact storage and packing
+
+fn main() {
+    let params = build::ParamsBuilder::default()
+        .custom_assets_named(vec![
+            ("Cargo.toml", "not.cargo"),
+            ("src", "no/src"),
+            ("Cargo.lock", "no/src/Cargo.unlock"),
+        ])
+        .custom_assets(vec!["Cargo.toml"])
+        .build()
+        .unwrap();
+    build::main(&params);
+}


### PR DESCRIPTION
Closes #95

Этот МР обновляет поле в `Params` - `custom_assets`, оно теперь является списком пар путей:
- первый путь в паре - файл/папка, которую хотим скопировать
- второй - новое название файла/папки в папке `assets`

Добавить пару можно с помощью вызова функции `custom_assets_named`

Для обратной совместимости, теперь в функции `custom_assets` в качестве дестинейшена для пути будет браться крайнее название файла/папки, переданного в функцию

То есть, теперь, для передачи ассетов будет такой синтакс:
```rust
fn main() {
    let params = build::ParamsBuilder::default()
        .custom_assets_named(vec![
            ("Cargo.toml", "not.cargo"), // переименование файла
            ("src", "no/src"), // переименование папки
            ("Cargo.lock", "no/src/Cargo.unlock"), // создание папки с файлом
        ])
        .custom_assets(vec!["Cargo.toml"]) // просто добавление в папку assets
        .build()
        .unwrap();
    build::main(&params);
}
```