### PR TITLE
Добавление возможности копировать файлы/папки в ассеты с новым путем

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [UNRELEASED]
 
+### Added
+
+- Support adding custom assets under desired names (921dec0)
+
 ### Fixed
 
 - Move all necessary files to the root folder of the workspace (fa293fc9)

--- a/tests/assets/custom_assets_with_targets_build.rs
+++ b/tests/assets/custom_assets_with_targets_build.rs
@@ -1,0 +1,14 @@
+use pike::helpers::build;
+
+fn main() {
+    let params = build::ParamsBuilder::default()
+        .custom_assets_with_targets(vec![
+            ("Cargo.toml", "not.cargo"),
+            ("src", "other/name"),
+            ("Cargo.lock", "other/name/Cargo.unlock"),
+        ])
+        .custom_assets(vec!["Cargo.toml"])
+        .build()
+        .unwrap();
+    build::main(&params);
+}


### PR DESCRIPTION
Closes #95

Этот МР обновляет поле в `Params` - `custom_assets`, оно теперь является списком пар путей:
- первый путь в паре - файл/папка, которую хотим скопировать
- второй - новое название файла/папки в папке `assets`

Добавить пару можно с помощью вызова функции `custom_assets_named`

Для обратной совместимости, теперь в функции `custom_assets` в качестве дестинейшена для пути будет браться крайнее название файла/папки, переданного в функцию

То есть, теперь, для передачи ассетов будет такой синтакс:
```rust
fn main() {
    let params = build::ParamsBuilder::default()
        .custom_assets_named(vec![
            ("Cargo.toml", "not.cargo"), // переименование файла
            ("src", "other/name"), // переименование папки
            ("Cargo.lock", "folder/Cargo.unlock"), // создание папки с файлом
        ])
        .custom_assets(vec!["Cargo.toml"]) // просто добавление в папку assets
        .build()
        .unwrap();
    build::main(&params);
}
```