### PR TITLE
feat: support stopping of specific cluster instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,27 @@ cargo pike stop --data-dir ./tmp
 [*] stopping picodata instance: i4
 ```
 
+Для того, чтобы остановить только один инстанс в кластере, необходимо передать его название в опцию `--instance-name`.
+Пайк остановит только указанный инстанс, а остальные продолжат свое выполнение.
+
+Например,
+
+```bash
+cargo pike stop --data-dir ./tmp --instance-name i2
+```
+
+Вывод:
+
+```bash
+[*] stopping picodata cluster instance 'i2', data folder: ./tmp/i2
+[*] stopping picodata instance: i2 - OK
+```
+
 #### Доступные опции
 
 - `--data-dir <DATA_DIR>` - Путь к директории хранения файлов кластера. Значение по умолчанию: `./tmp`
 - `--plugin-path` - Путь до директории **проекта** плагина. Значение по умолчанию: `./`
+- `--instance-name <INSTANCE_NAME>` - Название инстанса Пикодаты. По умолчанию игнорируется.
 
 ### `enter`
 

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,3 +1,4 @@
+use crate::commands::lib::get_active_socket_path;
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use derive_builder::Builder;
@@ -7,14 +8,14 @@ use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::commands::lib::get_active_socket_path;
-
 #[derive(Debug, Builder)]
 pub struct Params {
     #[builder(default = "PathBuf::from(\"./tmp\")")]
     data_dir: PathBuf,
     #[builder(default = "PathBuf::from(\"./\")")]
     plugin_path: PathBuf,
+    #[builder(default)]
+    instance_name: Option<String>,
 }
 
 pub fn cmd(params: &Params) -> Result<()> {
@@ -24,64 +25,99 @@ pub fn cmd(params: &Params) -> Result<()> {
         instances_path.to_string_lossy()
     ))?;
 
-    info!(
-        "stopping picodata cluster, data folder: {}",
-        params.data_dir.to_string_lossy()
-    );
+    if let Some(instance_name) = &params.instance_name {
+        info!(
+            "stopping picodata cluster instance '{instance_name}', data folder: {}",
+            instances_path.join(instance_name).to_string_lossy()
+        );
 
-    // Iterate through instance folders and
-    // search for "pid" file. After the pid
-    // is known - kill the instance
-    for current_dir in dirs {
-        let instance_dir = current_dir?.path();
+        // Find directory that belongs to stopping instance.
+        let instance_dir = dirs.into_iter().find_map(|result| {
+            let Ok(dir_entry) = result else {
+                return None;
+            };
 
-        // To get the actual instance name, we look
-        // only on simlinks
-        if !fs::symlink_metadata(&instance_dir)?.is_symlink() {
-            continue;
-        }
+            if dir_entry.file_name() != instance_name.as_str() {
+                return None;
+            }
 
-        if !instance_dir.is_dir() {
-            bail!("{} is not a directory", instance_dir.to_string_lossy());
-        }
-        let Some(link_name) = instance_dir.file_name() else {
-            continue;
+            Some(dir_entry.path())
+        });
+
+        let Some(instance_dir) = instance_dir else {
+            bail!("failed to locate directory of the instance '{instance_name}'");
         };
 
-        let pid_file_path = instance_dir.join("pid");
-        if !pid_file_path.exists() {
-            bail!(
-                "PID file does not exist in folder: {}",
-                instance_dir.display()
-            );
+        stop_instance(params, &instance_dir)
+    } else {
+        info!(
+            "stopping picodata cluster, data folder: {}",
+            params.data_dir.to_string_lossy()
+        );
+
+        // Iterate through instance folders and
+        // search for "pid" file. After the pid
+        // is known - kill the instance
+        for current_dir in dirs {
+            let instance_dir = current_dir?.path();
+
+            // To get the actual instance name, we look
+            // only on simlinks
+            if !fs::symlink_metadata(&instance_dir)?.is_symlink() {
+                continue;
+            }
+
+            stop_instance(params, &instance_dir)?;
         }
 
-        let pid = read_pid_from_file(&pid_file_path).context("failed to read the PID file")?;
+        Ok(())
+    }
+}
 
-        if get_active_socket_path(
-            &params.data_dir,
-            &params.plugin_path,
-            link_name.to_str().unwrap(),
-        )
-        .is_none()
-        {
-            info!(
-                "stopping picodata instance: {} - {}",
-                link_name.to_string_lossy(),
-                "SKIPPED".yellow()
-            );
-            continue;
-        }
+fn stop_instance(params: &Params, instance_dir: &Path) -> Result<()> {
+    if !instance_dir.is_dir() {
+        bail!("{} is not a directory", instance_dir.to_string_lossy());
+    }
+    let Some(link_name) = instance_dir.file_name() else {
+        bail!(
+            "failed to obtain filename from {}",
+            instance_dir.to_string_lossy()
+        );
+    };
 
-        if let Err(e) = kill_process_by_pid(pid) {
-            bail!("failed to stop picodata instance with PID {pid}. Error: {e}");
-        }
+    let pid_file_path = instance_dir.join("pid");
+    if !pid_file_path.exists() {
+        bail!(
+            "PID file does not exist in folder: {}",
+            instance_dir.display()
+        );
+    }
+
+    let pid = read_pid_from_file(&pid_file_path).context("failed to read the PID file")?;
+
+    if get_active_socket_path(
+        &params.data_dir,
+        &params.plugin_path,
+        link_name.to_str().unwrap(),
+    )
+    .is_none()
+    {
         info!(
             "stopping picodata instance: {} - {}",
             link_name.to_string_lossy(),
-            "OK".green()
+            "SKIPPED".yellow()
         );
+        return Ok(());
     }
+
+    if let Err(e) = kill_process_by_pid(pid) {
+        bail!("failed to stop picodata instance with PID {pid}. Error: {e}");
+    }
+    info!(
+        "stopping picodata instance: {} - {}",
+        link_name.to_string_lossy(),
+        "OK".green()
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ enum Command {
         #[arg(long, value_name = "CONFIG_PATH", default_value = "./picodata.yaml")]
         config_path: PathBuf,
     },
-    /// Stop Picodata cluster
+    /// Stop Picodata cluster or a specific instance
     Stop {
         /// Path to data directory of the cluster
         #[arg(long, value_name = "DATA_DIR", default_value = "./tmp")]
@@ -121,6 +121,10 @@ enum Command {
         /// Path to the plugin's project directory
         #[arg(long, value_name = "PLUGIN_PATH", default_value = "./")]
         plugin_path: PathBuf,
+        /// Name of the instance to stop. If not specified, this command
+        /// will stop all instances in the cluster.
+        #[arg(long, value_name = "INSTANCE_NAME", default_value = None)]
+        instance_name: Option<String>,
     },
     /// Remove all data files of previous cluster run
     Clean {
@@ -389,6 +393,7 @@ fn main() -> Result<()> {
         Command::Stop {
             data_dir,
             plugin_path,
+            instance_name,
         } => {
             is_required_path_exists(&plugin_path, &data_dir, CARING_PIKE, 1);
 
@@ -396,6 +401,7 @@ fn main() -> Result<()> {
             let params = commands::stop::ParamsBuilder::default()
                 .data_dir(data_dir)
                 .plugin_path(plugin_path)
+                .instance_name(instance_name)
                 .build()
                 .unwrap();
             commands::stop::cmd(&params).context("failed to execute \"stop\" command")?;


### PR DESCRIPTION
This change adds new optional argument to pike::stop command called '--instance-name'. If pike stop is running with --instance-name option, then only instance specified in this option will be stoped. Other running instance will not be affected.

Closes #190