### PR TITLE
feat: support cluster run with external plugins (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Support running external plugins without a parent plugin project
 - Add `--archive-name` option to `plugin pack`
 - Add validation of picodata.yaml config
 - Add `--picodata-path` option to `config apply` command


### PR DESCRIPTION
topology.toml

[tier.default]
replicasets = 1
replication_factor = 3

[plugin.my-plugin]
path = "./pike-manual-inner-test/my-plugin/./target/release/my-plugin_0.1.0-arch_rolling.tar.gz"
migration_context = []

[plugin.my-plugin.service.example_service]
tiers = ["default"]

[enviroment]
RADIX_LISTEN_ADDR = "0.0.0.0:{{ instance_id | plus: 7500 }}"
RADIX_ADVERTISE_ADDR = "localhost:{{ instance_id | plus: 7500 }}"
PICODATA_LOG_LEVEL = "info"
PICODATA_UNSAFE_DISABLE_PLUGIN_COMPATIBILITY_CHECK = "1"
PICODATA_INTERNAL_ON_SHUTDOWN_TIMEOUT = "3.0"
PICODATA_HTTP_LISTEN = "127.0.0.1:{{ instance_id | plus: 18000 }}"

picodata.yaml

cluster:
  name: my-plugin_0.1.0-arch_rolling
  default_bucket_count: 16384
instance:
  memtx:
    memory: 2000000000

❯ cargo pike run | grep '[*]'
[*] Found 1 external plugins, loading into "././tmp/cluster/plugins"
[*] Running the cluster...
[*] i1 - started
[*] Waiting for 'default_1_2' to become 'Online'
[*] Waiting for 'default_1_2' to become 'Online'
[*] Waiting for 'default_1_2' to become 'Online'
[*] Waiting for 'default_1_2' to become 'Online'
[*] Waiting for 'default_1_2' to become 'Online'
[*] i2 - started
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] Waiting for 'default_1_3' to become 'Online'
[*] i3 - started
[*] Waiting for cluster RAFT leader to be negotiated (timeout 15s)
[*] Cluster leader id is 1
[*] WebUI auth: отключена (jwt_secret='').
[*] Enabling plugins...
[*] picodata admin: CREATE PLUGIN "my-plugin" 0.1.0;
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
[*] picodata admin: ALTER PLUGIN "my-plugin" MIGRATE TO 0.1.0;
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
[*] picodata admin: ALTER PLUGIN "my-plugin" 0.1.0 ADD SERVICE "example_service" TO TIER "default";
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
[*] picodata admin: ALTER PLUGIN "my-plugin" 0.1.0 ENABLE;
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
[*] Plugin my-plugin:0.1.0 has been enabled
[*] Picodata cluster has started (launch time: 3 sec, total instances: 3)

При удалении плагина имеем вывод:

❯ cargo pike run | grep '[*]'
[*] Found 1 external plugins, loading into "././tmp/cluster/plugins"
Error: failed to execute Run command

Caused by:
    0: failed to validate external path ./pike-manual-inner-test/my-plugin/./target/release/my-plugin_0.1.0-arch_rolling.tar.gz for plugin my-plugin
    1: failed to query external plugin path metadata
    2: No such file or directory (os error 2)
[1]    208254 exit 1     cargo pike run |
       208255 killed     grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn,.idea,.tox,.venv,venv