### PR TITLE
feat: add --picodata-path option for config apply (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Add validation of picodata.yaml config
+- Add `--picodata-path` option to `config apply` command
 - Add optional `--no-build` flag to `plugin pack` command
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -391,3 +391,4 @@ cargo pike config apply
 
 - `-c, --config-path <CONFIG>` - Путь к файлу конфига. Значение по умолчанию: `plugin_config.yaml`
 - `--data-dir <DATA_DIR>` - Путь к директории хранения файлов кластера. Значение по умолчанию: `./tmp`
+- `--picodata-path <BINARY_PATH>` - Путь к бинарному файлу Picodata, который будет использоваться для вызова picodata admin при применении конфига. По умолчанию используется `picodata` из `$PATH`

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,8 @@ enum Config {
         /// Choose plugin which config should be applied
         #[arg(long, value_name = "PLUGIN_NAME")]
         plugin_name: Option<String>,
+        #[arg(long, value_name = "BINARY_PATH", default_value = "picodata")]
+        picodata_path: PathBuf,
     },
 }
 
@@ -513,12 +515,14 @@ fn main() -> Result<()> {
                     data_dir,
                     plugin_path,
                     plugin_name,
+                    picodata_path,
                 } => {
                     let params = commands::config::apply::ParamsBuilder::default()
                         .config_path(config_path)
                         .data_dir(data_dir)
                         .plugin_path(plugin_path)
                         .plugin_name(plugin_name)
+                        .picodata_path(picodata_path)
                         .build()
                         .unwrap();
                     commands::config::apply::cmd(&params)


### PR DESCRIPTION
❯ cargo pike config apply
[*] Applying plugin config
[*] picodata admin: ALTER PLUGIN "test_plugin" 0.1.0 SET "example_service"."value"='"changed"';
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
❯ cargo pike config apply --picodata-path /home/gs0xa19f2/Documents/picodata/picodata-25.2.1/target/debug/picodata
error: unexpected argument '--picodata-path' found

Usage: cargo pike config apply [OPTIONS]

For more information, try '--help'.
❯ export PATH="/tmp/pike-test"/bin:$PATH
❯ which cargo-pike
/tmp/pike-test/bin/cargo-pike
❯ cargo pike config apply --picodata-path /home/gs0xa19f2/Documents/picodata/picodata-25.2.1/target/debug/picodata
[*] Applying plugin config
[*] picodata admin: ALTER PLUGIN "test_plugin" 0.1.0 SET "example_service"."value"='"changed"';
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
❯ cargo pike config apply --picodata-path /home/gs0xa19f2/Documents/picodata/picodata-25.2.3/target/debug/picodata
[*] Applying plugin config
[*] picodata admin: ALTER PLUGIN "test_plugin" 0.1.0 SET "example_service"."value"='"changed"';
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
❯ cargo pike config apply --picodata-path /home/gs0xa19f2/Documents/picodata/picodata-25.4.2/target/debug/picodata
[*] Applying plugin config
[*] picodata admin: ALTER PLUGIN "test_plugin" 0.1.0 SET "example_service"."value"='"changed"';
[*] picodata admin: Connected to admin console by socket path "././tmp/cluster/i1/admin.sock"
[*] picodata admin: type '\help' for interactive help
[*] picodata admin: 1
[*] picodata admin: Bye
❯ cargo pike config apply --picodata-path /home/gs0xa19f2/Documents/picodata/non-existent-version/target/debug/picodata
[*] Applying plugin config
[*] picodata admin: ALTER PLUGIN "test_plugin" 0.1.0 SET "example_service"."value"='"changed"';
Error: failed to execute "config apply" command

Caused by:
    0: failed to apply service config for service example_service
    1: failed to run picodata admin
    2: No such file or directory (os error 2)