### PR TITLE
build: support FreeBSD OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Add optional `--with_audit` flag to `pike run`, explicitly enabling audit log.
+- Add support for FreeBSD OS
 
 ## [3.0.0]
 

--- a/src/commands/lib/mod.rs
+++ b/src/commands/lib/mod.rs
@@ -11,7 +11,7 @@ use tar::Archive;
 
 pub mod instance_info;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub const LIB_EXT: &str = "so";
 
 #[cfg(target_os = "macos")]

--- a/src/commands/plugin/pack.rs
+++ b/src/commands/plugin/pack.rs
@@ -293,9 +293,9 @@ fn generate_archive_path(
 
 // ---------------- OS detection (per target) ----------------
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn detect_os_suffix() -> Result<String> {
-    detect_linux_os_suffix()
+    detect_linux_freebsd_os_suffix()
 }
 
 #[cfg(target_os = "macos")]
@@ -303,13 +303,13 @@ fn detect_os_suffix() -> Result<String> {
     detect_macos_os_suffix()
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "freebsd")))]
 fn detect_os_suffix() -> Result<String> {
     bail!("unsupported operating system for packing plugin (supported: linux, macos)");
 }
 
-#[cfg(target_os = "linux")]
-fn detect_linux_os_suffix() -> Result<String> {
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+fn detect_linux_freebsd_os_suffix() -> Result<String> {
     const OS_RELEASE: &str = "/etc/os-release";
     const ROLLING_DISTROS: &[&str] = &[
         "arch",
@@ -371,7 +371,7 @@ fn detect_linux_os_suffix() -> Result<String> {
     Ok(format!("{id}_{variant}"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn resolve_linux_variant(id: &str, rolling: &[&str]) -> String {
     if rolling.iter().any(|d| *d == id) {
         "rolling".to_string()

--- a/src/helpers/build/mod.rs
+++ b/src/helpers/build/mod.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 const MANIFEST_TEMPLATE_NAME: &str = "manifest.yaml.template";
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub const LIB_EXT: &str = "so";
 
 #[cfg(target_os = "macos")]

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -27,7 +27,7 @@ pub const PLUGIN_DIR: &str = concat!(TESTS_DIR, PLUGIN_NAME);
 pub const SHARED_TARGET_NAME: &str = "shared_target";
 pub const SHARED_TARGET_PATH: &str = concat!(TESTS_DIR, SHARED_TARGET_NAME);
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub const LIB_EXT: &str = "so";
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Add target_os = "freebsd" to configuration gates as current code for Linux is fully compatible with FreeBSD.

Note that integration tests will only succeed on FreeBSD starting from the next picodata-pike release as they use versioned dependencies through Cargo.toml.
