### PR TITLE
Moved `picotest` to dev dependencies

### DIFF
--- a/plugin_template/_Cargo.toml
+++ b/plugin_template/_Cargo.toml
@@ -13,12 +13,12 @@ anyhow = "1.0.98"
 rmpv = "1.0.0"
 shors = "0.12.3"
 rmp-serde = "1.0.0"
-picotest = "1.8.1"
 
 [dev-dependencies]
 tokio = "1.29.1"
 rstest = "0.25.0"
 reqwest = { version = "0.12", features = ["blocking"] }
+picotest = "1.8.1"
 
 [build-dependencies]
 picodata-pike = "3.0.0"


### PR DESCRIPTION
It looks like `picotest` is only required for... tests... so probably good idea to move it to dev dependencies.