### PR TITLE
Added `prometheus` as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Add optional `--with_audit` flag to `pike run`, explicitly enabling audit log.
 - Add support for FreeBSD OS
+- Add Prometheus to depencencies in plugin template
 
 ## [3.0.0]
 

--- a/plugin_template/_Cargo.toml
+++ b/plugin_template/_Cargo.toml
@@ -14,6 +14,7 @@ rmpv = "1.0.0"
 shors = "0.12.3"
 rmp-serde = "1.0.0"
 picotest = "1.8.1"
+prometheus = "0.14.0"
 
 [dev-dependencies]
 tokio = "1.29.1"


### PR DESCRIPTION
It looks like Prometheus is a common dependency for all plugins, so we could include it in plugin template.