### PR TITLE
feat: improve detection of vshard rebalancing completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [UNRELEASED]
 
+### Added
+
+- Check cluster readiness using both `/startup` and `/ready` probes
+- Improve handling of vshard discovery completion [#330](https://github.com/picodata/pike/issues/330)
+
 ## [4.0.0]
 
 ### Breaking Changes

--- a/src/commands/lib/instance_info.rs
+++ b/src/commands/lib/instance_info.rs
@@ -1,5 +1,7 @@
 use crate::commands::lib::run_query_in_picodata_admin;
 use anyhow::{bail, Context, Result};
+use log::warn;
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::{
     path::{Path, PathBuf},
@@ -10,6 +12,45 @@ const ADMIN_SOCKET_FILENAME: &str = "admin.sock";
 
 const GET_INSTANCE_NAME: &str = "\\lua\npico.instance_info().name";
 const GET_INSTANCE_CURRENT_STATE: &str = "\\lua\npico.instance_info().current_state.variant";
+
+// Get configured number of buckets in the instance tier.
+const GET_TIER_BUCKET_COUNT: &str =
+    "\\lua\nbox.space._pico_tier:get{pico.whoami().tier}.bucket_count";
+
+// Get configured number of replicasets in the instance tier.
+const GET_TIER_REPLICASET_COUNT: &str =
+    "\\lua\npico.sql(\"select count(*) from _pico_replicaset where tier = ?\", {pico.whoami().tier}).rows[1][1]";
+
+// Get the UUID of the instance's replicaset.
+const GET_REPLICASET_UUID: &str =
+    "\\lua\npico.sql(\"select replicaset_uuid from _pico_instance where name = ?\", {pico.whoami().instance_name}).rows[1][1]";
+
+// Get current number of buckets located on the instance
+const GET_INSTANCE_BUCKET_COUNT: &str = "\\lua\nbox.space._bucket:count()";
+
+// Get map of [replicaset_uuid, bucket_count] obtained from
+// vshard router for all tiers.
+const GET_VSHARD_REPLICASET_MAP: &str = "\\lua\n\
+local out = {}; \
+for _, router in pairs(vshard.router.internal.routers) do \
+    for uuid, rs in pairs(router.replicasets) do \
+        out[uuid] = rs.bucket_count; \
+    end; \
+end; \
+return require('json').encode(out)";
+
+fn parse_lua_json(lua_output: &str) -> Result<HashMap<String, u32>> {
+    let trimmed = lua_output.trim();
+
+    // remove wrapping single quotes if present
+    let json = if trimmed.starts_with('\'') && trimmed.ends_with('\'') {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+
+    Ok(serde_json::from_str(json)?)
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum InstanceState {
@@ -89,5 +130,51 @@ impl<'a> InstanceSocketClient<'a> {
     pub fn current_state(&self) -> Result<InstanceState> {
         self.get_lua_single_line_output(GET_INSTANCE_CURRENT_STATE)
             .and_then(|state| state.parse())
+    }
+
+    // Fetches map of [replicaset_uuid, bucket_count] obtained from
+    // vshard router for the instance tier.
+    pub fn vshard_replicaset_map(&self) -> Result<HashMap<String, u32>> {
+        self.get_lua_single_line_output(GET_VSHARD_REPLICASET_MAP)
+            .and_then(|o| parse_lua_json(&o))
+    }
+
+    /// Fetches configured number of buckets in the instance tier.
+    pub fn tier_bucket_count(&self) -> Result<u32> {
+        self.get_parsed_lua_output(GET_TIER_BUCKET_COUNT)
+    }
+
+    /// Fetches configured number of replicasets in the instance tier.
+    pub fn tier_replicaset_count(&self) -> Result<u32> {
+        self.get_parsed_lua_output(GET_TIER_REPLICASET_COUNT)
+    }
+
+    /// Fetches current number of buckets located on the instance
+    pub fn bucket_count(&self) -> Result<u32> {
+        self.get_parsed_lua_output(GET_INSTANCE_BUCKET_COUNT)
+    }
+
+    /// Fetches UUID of the instance's replicaset.
+    pub fn replicaset_uuid(&self) -> Result<String> {
+        self.get_parsed_lua_output(GET_REPLICASET_UUID)
+    }
+
+    /// Checks whether current instance is a master in replicaset
+    /// according to `_pico_replicaset` table.
+    pub fn is_master_of_replicaset(&self, replicaset_uuid: &str) -> Result<bool> {
+        let instance_name = self.instance_name()?;
+
+        let current_master_name: String = self.get_parsed_lua_output(&format!(
+            "\\lua\npico.sql(\"select current_master_name from _pico_replicaset where uuid = ?\", {{ \"{replicaset_uuid}\" }}).rows[1][1]",
+        ))?;
+        let target_master_name: String = self.get_parsed_lua_output(&format!(
+            "\\lua\npico.sql(\"select target_master_name from _pico_replicaset where uuid = ?\", {{ \"{replicaset_uuid}\" }}).rows[1][1]",
+        ))?;
+
+        if current_master_name != target_master_name {
+            warn!("Master change is in progress; using target master name");
+        }
+
+        Ok(instance_name == target_master_name)
     }
 }

--- a/src/commands/lib/instance_info.rs
+++ b/src/commands/lib/instance_info.rs
@@ -1,6 +1,12 @@
 use crate::commands::lib::run_query_in_picodata_admin;
-use anyhow::{bail, Result};
-use std::{path::Path, str::FromStr};
+use anyhow::{bail, Context, Result};
+use std::error::Error as StdError;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+const ADMIN_SOCKET_FILENAME: &str = "admin.sock";
 
 const GET_INSTANCE_NAME: &str = "\\lua\npico.instance_info().name";
 const GET_INSTANCE_CURRENT_STATE: &str = "\\lua\npico.instance_info().current_state.variant";
@@ -33,35 +39,55 @@ impl FromStr for InstanceState {
     }
 }
 
-/// Runs input query in picodata admin.
-///
-/// Only single line is extracted from returned STDOUT.
-fn get_lua_single_line_output(
-    picodata_path: &Path,
-    socket_path: &Path,
-    lua_query: &str,
-) -> Result<String> {
-    let stdout = run_query_in_picodata_admin(picodata_path, socket_path, lua_query)?;
-
-    let Some(output) = stdout.lines().find_map(|line| line.strip_prefix("- ")) else {
-        bail!("unable to extract single line from Lua query output '{stdout}'");
-    };
-
-    Ok(output.to_string())
+/// Client for interacting with a Picodata
+/// instance over its admin socket.
+pub struct InstanceSocketClient<'a> {
+    socket_path: PathBuf,
+    picodata_path: &'a PathBuf,
 }
 
-pub fn get_instance_name(picodata_path: &Path, instance_data_dir: &Path) -> Result<String> {
-    let instance_socket = instance_data_dir.join("admin.sock");
+impl<'a> InstanceSocketClient<'a> {
+    pub fn new(instance_data_dir: &Path, picodata_path: &'a PathBuf) -> Self {
+        Self {
+            socket_path: instance_data_dir.join(ADMIN_SOCKET_FILENAME),
+            picodata_path,
+        }
+    }
 
-    get_lua_single_line_output(picodata_path, &instance_socket, GET_INSTANCE_NAME)
-}
+    /// Runs input query in picodata admin.
+    ///
+    /// Only single line is extracted from returned STDOUT.
+    fn get_lua_single_line_output(&self, lua_query: &str) -> Result<String> {
+        let stdout = run_query_in_picodata_admin(self.picodata_path, &self.socket_path, lua_query)?;
 
-pub fn get_instance_current_state(
-    picodata_path: &Path,
-    instance_data_dir: &Path,
-) -> Result<InstanceState> {
-    let instance_socket = instance_data_dir.join("admin.sock");
+        let Some(output) = stdout.lines().find_map(|line| line.strip_prefix("- ")) else {
+            bail!("unable to extract single line from Lua query output '{stdout}'");
+        };
 
-    get_lua_single_line_output(picodata_path, &instance_socket, GET_INSTANCE_CURRENT_STATE)
-        .and_then(|state| state.parse())
+        Ok(output.to_string())
+    }
+
+    fn get_parsed_lua_output<T>(&self, lua_query: &str) -> anyhow::Result<T>
+    where
+        T: FromStr,
+        T::Err: StdError + Send + Sync + 'static,
+    {
+        let raw = self
+            .get_lua_single_line_output(lua_query)
+            .context("failed to execute Lua query")?;
+
+        raw.parse::<T>()
+            .with_context(|| format!("failed to parse Lua output: {raw:?}"))
+    }
+
+    /// Fetches instance name from admin socket.
+    pub fn instance_name(&self) -> Result<String> {
+        self.get_parsed_lua_output(GET_INSTANCE_NAME)
+    }
+
+    /// Fetches state of the instance from admin socket.
+    pub fn current_state(&self) -> Result<InstanceState> {
+        self.get_lua_single_line_output(GET_INSTANCE_CURRENT_STATE)
+            .and_then(|state| state.parse())
+    }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -493,8 +493,8 @@ impl PicodataInstance {
         self.http_port
     }
 
-    pub(crate) fn data_dir(&self) -> &Path {
-        &self.data_dir
+    pub(crate) fn socket_client<'a>(&self, picodata_path: &'a PathBuf) -> InstanceSocketClient<'a> {
+        InstanceSocketClient::new(&self.data_dir, picodata_path)
     }
 
     #[allow(dead_code)]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use crate::commands::lib::instance_info::{get_instance_current_state, get_instance_name};
+use crate::commands::lib::instance_info::InstanceSocketClient;
 use crate::commands::lib::{
     cargo_build, copy_directory_tree, find_active_socket_path, get_cluster_dir,
     log_instance_skipped, log_instance_started, run_query_in_picodata_admin, spawn_picodata_admin,
@@ -437,17 +437,18 @@ impl PicodataInstance {
         let start = Instant::now();
         while Instant::now().duration_since(start) < TIMEOUT_WAITING_FOR_INSTANCE_READINESS {
             thread::sleep(Duration::from_millis(100));
-            let Ok(new_instance_name) =
-                get_instance_name(&run_params.picodata_path, &instance_data_dir)
-                    .inspect_err(|err| log::debug!("failed to get name of the instance: {err}"))
+            let socket_client =
+                InstanceSocketClient::new(&instance_data_dir, &run_params.picodata_path);
+            let Ok(new_instance_name) = socket_client
+                .instance_name()
+                .inspect_err(|err| log::debug!("failed to get name of the instance: {err}"))
             else {
                 continue;
             };
 
             // If name is already known, then socket is ready, i.e. we assume
             // call below should return without error.
-            let instance_current_state =
-                get_instance_current_state(&run_params.picodata_path, &instance_data_dir)?;
+            let instance_current_state = socket_client.current_state()?;
             if !instance_current_state.is_online() {
                 info!("Waiting for '{new_instance_name}' to become 'Online'");
                 continue;

--- a/src/commands/run/readiness.rs
+++ b/src/commands/run/readiness.rs
@@ -1,8 +1,9 @@
-use crate::commands::lib::run_query_in_picodata_admin;
 use crate::commands::run::Params;
 use crate::healthcheck::api;
 use anyhow::{bail, Result};
 use log::{debug, info};
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -11,7 +12,7 @@ use super::PicodataInstance;
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(60);
 const CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
-/// Polls `GET /api/v1/health/ready` on each instance until all return 200,
+/// Polls startup and readiness probes on each instance until all return 200,
 /// or until the timeout is exceeded.
 pub(super) fn wait_instances_ready(instances: &[PicodataInstance]) -> Result<()> {
     if instances.is_empty() {
@@ -56,9 +57,18 @@ pub(super) fn wait_instances_ready(instances: &[PicodataInstance]) -> Result<()>
     }
 }
 
-/// Polls vshard router state via admin socket on each instance until
-/// `bucket_count: {active_buckets}` appears in `vshard.router` output,
-/// indicating that vshard discovery has settled.
+/// Waits for vshard discovery to complete across all instances.
+///
+/// The routine ensures the cluster reaches a consistent and fully initialized state in two phases:
+///
+/// 1. Initial resharding:
+///    Waits until buckets are evenly distributed across instances. For each replicaset,
+///    collects the number of buckets from master instances.
+///
+/// 2. Vshard initialization:
+///    Waits until `vshard.router` on every instance reflects the actual cluster state by
+///    verifying that bucket counts per replicaset match those observed on storage.
+///
 pub(super) fn wait_vshard_discovery(instances: &[PicodataInstance], params: &Params) -> Result<()> {
     let timeout = Duration::from_secs(params.wait_vshard_discovery_timeout);
     info!(
@@ -67,43 +77,161 @@ pub(super) fn wait_vshard_discovery(instances: &[PicodataInstance], params: &Par
         timeout.as_secs()
     );
 
-    for instance in instances {
-        let socket_path = instance.data_dir().join("admin.sock");
-        let start = Instant::now();
-        let active_buckets = api::get_health_status(instance)?.buckets.active;
-        let needle = format!("bucket_count: {active_buckets}");
+    let start = Instant::now();
+    let picodata_path = &params.picodata_path;
+    let bucket_count_per_replicaset =
+        wait_for_initial_resharding(instances, picodata_path, timeout)?;
 
-        loop {
+    let Some(time_left) = timeout.checked_sub(start.elapsed()) else {
+        bail!("no time left for vshard initialization");
+    };
+
+    wait_for_vshard_router_init(
+        instances,
+        picodata_path,
+        &bucket_count_per_replicaset,
+        time_left,
+    )?;
+
+    info!(
+        "Vshard discovery has been completed on all instances within {:.2?}",
+        start.elapsed()
+    );
+
+    Ok(())
+}
+
+// Waits for initial vshard resharding to complete on all instances.
+// Returns a map of replicaset UUID → bucket count (collected from masters),
+// or fails if the timeout is exceeded.
+fn wait_for_initial_resharding(
+    instances: &[PicodataInstance],
+    picodata_path: &PathBuf,
+    timeout: Duration,
+) -> Result<HashMap<String, u32>> {
+    let start = Instant::now();
+    let mut bucket_count_per_replicaset: HashMap<String, u32> = HashMap::new();
+
+    info!(
+        "Waiting for initial resharding (timeout {}s)",
+        timeout.as_secs()
+    );
+
+    for instance in instances {
+        let instance_socket = instance.socket_client(picodata_path);
+        let tier_replicaset_count: u32 = instance_socket.tier_replicaset_count()?;
+        let tier_bucket_count: u32 = instance_socket.tier_bucket_count()?;
+
+        // Wait for the current instance to complete resharding.
+
+        debug!(
+            "Instance '{}': awaiting resharding completion",
+            instance.instance_name
+        );
+
+        let instance_bucket_count = loop {
+            let instance_bucket_count: u32 = instance_socket.bucket_count()?;
+
+            if (tier_replicaset_count * instance_bucket_count).abs_diff(tier_bucket_count)
+                < tier_replicaset_count
+            {
+                debug!(
+                    "Instance '{}': resharding completed (bucket_count = {})",
+                    instance.instance_name, instance_bucket_count
+                );
+                break instance_bucket_count;
+            }
+
             if start.elapsed() >= timeout {
                 bail!(
-                    "vshard discovery timed out: '{needle}' not found in vshard.router output \
-                     on instance {} within {}s",
-                    instance.http_port(),
+                    "Resharding timed out on instance '{}' within {}s",
+                    instance.instance_name,
                     timeout.as_secs()
                 );
             }
 
-            let output = run_query_in_picodata_admin(
-                &params.picodata_path,
-                &socket_path,
-                "\\lua\nvshard.router",
-            );
+            thread::sleep(CHECK_INTERVAL);
+        };
 
-            match output {
-                Ok(stdout) if stdout.contains(&needle) => break,
-                Ok(_) => {}
-                Err(e) => {
+        // If current instance is master, preserve number of buckets in the map.
+        let replicaset_uuid: String = instance_socket.replicaset_uuid()?;
+
+        if instance_socket.is_master_of_replicaset(&replicaset_uuid)? {
+            info!("Replicaset '{replicaset_uuid}' has {instance_bucket_count} known bucket(s)",);
+            bucket_count_per_replicaset.insert(replicaset_uuid, instance_bucket_count);
+        }
+    }
+
+    info!(
+        "Initial resharding completed across all instances in {:.2?}",
+        start.elapsed()
+    );
+
+    Ok(bucket_count_per_replicaset)
+}
+
+/// Waits until vshard.router is initialized and synchronized on all instances,
+/// or returns an error if the timeout is exceeded.
+fn wait_for_vshard_router_init(
+    instances: &[PicodataInstance],
+    picodata_path: &PathBuf,
+    bucket_count_per_replicaset: &HashMap<String, u32>,
+    timeout: Duration,
+) -> Result<()> {
+    let start = Instant::now();
+
+    info!(
+        "Waiting for vshard initialization (timeout {}s)",
+        timeout.as_secs()
+    );
+
+    for instance in instances {
+        let instance_socket = instance.socket_client(picodata_path);
+
+        debug!(
+            "Instance '{}': awaiting vshard.router initialization",
+            instance.instance_name
+        );
+
+        loop {
+            // Fetch vshard.router map from socket.
+            match instance_socket.vshard_replicaset_map() {
+                Ok(map) if map == *bucket_count_per_replicaset => {
                     debug!(
-                        "vshard.router query failed on instance {}: {e}",
-                        instance.http_port()
+                        "Instance '{}': has synced vshard router",
+                        instance.instance_name
                     );
+                    break;
                 }
+                Ok(map) => {
+                    debug!(
+                        "Instance '{}': vshard.router not yet synced",
+                        instance.instance_name
+                    );
+                    debug!("vshard.router state: {map:?}");
+                }
+                Err(err) => {
+                    // Likely vshard.router not yet available, so
+                    // lua returned an error.
+                    debug!("Unable to get vshard replicaset map: {err:}");
+                }
+            }
+
+            if start.elapsed() >= timeout {
+                bail!(
+                    "Initialization of vshard.router timed out within {}s",
+                    timeout.as_secs()
+                );
             }
 
             thread::sleep(CHECK_INTERVAL);
         }
     }
 
-    info!("vshard discovery has been completed on all instances");
+    info!(
+        "Initialization of vshard.router completed on all instances within {:.2?}",
+        start.elapsed()
+    );
+
     Ok(())
 }

--- a/src/healthcheck/api.rs
+++ b/src/healthcheck/api.rs
@@ -2,13 +2,30 @@
 
 use crate::commands::run::PicodataInstance;
 use anyhow::{bail, Result};
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 const SESSION_ENDPOINT: &str = "api/v1/session";
 const READINESS_ENDPOINT: &str = "api/v1/health/ready";
+const STARTUP_ENDPOINT: &str = "api/v1/health/startup";
 const HEALTH_STATUS_ENDPOINT: &str = "api/v1/health/status";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+enum Probe {
+    Readiness,
+    Startup,
+}
+
+impl Probe {
+    fn path(&self) -> &'static str {
+        match self {
+            Probe::Startup => STARTUP_ENDPOINT,
+            Probe::Readiness => READINESS_ENDPOINT,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -92,6 +109,24 @@ fn build_client() -> Result<reqwest::blocking::Client> {
         .map_err(Into::into)
 }
 
+/// Assembles URL of instance probe.
+fn build_probe_url(i: &PicodataInstance, probe: &Probe) -> String {
+    format!("http://127.0.0.1:{}/{}", i.http_port(), probe.path())
+}
+
+/// Performs the specified probe on the instance via HTTP.
+/// Returns `true` if the response status is successful.
+fn check_instance_probe(
+    http_client: &Client,
+    instance: &PicodataInstance,
+    probe: &Probe,
+) -> Result<bool> {
+    let url = build_probe_url(instance, probe);
+    let response = http_client.get(url).send()?;
+
+    Ok(response.status().is_success())
+}
+
 /// Authenticates against `/api/v1/session` and returns JWT tokens.
 pub fn get_session_token(http_port: u16, username: &str, password: &str) -> Result<SessionToken> {
     let url = format!("http://127.0.0.1:{http_port}/{SESSION_ENDPOINT}");
@@ -123,16 +158,16 @@ pub fn get_health_status(instance: &PicodataInstance) -> Result<HealthStatus> {
     Ok(resp.json::<HealthStatus>()?)
 }
 
-/// Checks `GET /api/v1/health/ready` for the given instance.
-/// Returns `true` if the instance is ready (`HTTP_OK` received).
+/// Instance is ready, when it's started and ready to accept incoming traffic.
+///
+/// This routine polls "/startup" endpoint and on success polls "/ready".
+///
+/// Returns "true" if both returned `HTTP_OK`.
+///
 pub fn is_instance_ready(instance: &PicodataInstance) -> Result<bool> {
-    let url = format!(
-        "http://127.0.0.1:{}/{READINESS_ENDPOINT}",
-        instance.http_port()
-    );
-    let client = build_client()?;
-    match client.get(&url).send() {
-        Ok(resp) => Ok(resp.status().is_success()),
-        Err(e) => Err(e.into()),
-    }
+    let http_client = build_client()?;
+    let check_probe = |p| check_instance_probe(&http_client, instance, p);
+    let is_ready = check_probe(&Probe::Startup)? && check_probe(&Probe::Readiness)?;
+
+    Ok(is_ready)
 }


### PR DESCRIPTION
При включенном `--wait-vshard-discovery` мы теперь ожидаем готовность кластера в следующем порядке:
1. Ждем `HTTP_OK` на `/startup` и `/ready` пробы у каждого инстанса (startup гарантирует, что RF достигнут в каждом репликасете);
2. Ждем пока бакеты разъезжаются по инстансам (см. алгоритм в тикете)
3. Ждем пока `vshard.router` получит актуальное состояние: каждый репликасет будет иметь `bucket_count`, который совпадает с числом бакетов в спейсе `_bucket` для каждого из инстансов.

На 3ьем этапе мы по сути сравниваем две мапы:
- Первая получена из итерации по инстансам и сбора `_bucket:count()` на мастерах
- Вторая получена из `vshard.router.internal`

Эти мапы вглядят вот так и хранят количество бакетов для конкретного репликасета. Они должны быть равны между собой и тогда мы считаем, что состояние стороджа и `vshard`'a одинаковое.

```json
{
     "85801737-5412-418f-95f0-3fba79303114"  : 1500,
     "7ab378d0-56c6-4c31-be49-7bfe1c9e82b6"  : 1500
}
```

Closes #330 