### PR TITLE
feat: add signal selection support to stop command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,12 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -137,6 +158,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -599,6 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +651,30 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -797,6 +859,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +972,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "objc2"
@@ -1002,6 +1085,7 @@ dependencies = [
  "log",
  "minijinja",
  "nix",
+ "procfs",
  "rand",
  "regex",
  "rstest",
@@ -1084,6 +1168,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "flate2",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -1212,6 +1320,12 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1629,6 +1743,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,10 +1831,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde_ignored = "0.1.14"
 terminal_size = "0.4.4"
 ureq = { version = "3.3.0", features = ["json", "native-tls", "gzip"], default-features = false }
 minijinja = "2.19.0"
+procfs = "0.18.0"
 
 [lib]
 name = "pike"

--- a/README.md
+++ b/README.md
@@ -317,11 +317,38 @@ cargo pike stop --data-dir ./tmp --instance-name i2
 [*] stopping picodata instance: i2 - OK
 ```
 
+Также можно указать Unix-сигнал, который будет отправлен инстансам, при помощи опции `--signal`.
+По умолчанию используется `SIGKILL`.
+
+Например, для корректного завершения инстансов через `SIGTERM`:
+
+```bash
+cargo pike stop --data-dir ./tmp --signal SIGTERM
+```
+
+Пикодата использует timeout при graceful shutdown кластера. Таймаут задается через переменную окружения `PICODATA_INTERNAL_ON_SHUTDOWN_TIMEOUT` в секундах:
+
+```bash
+export PICODATA_INTERNAL_ON_SHUTDOWN_TIMEOUT="3.0"
+```
+
+Соответственно, при завершении кластера через `SIGTERM` инстансы будут завершаться в течение времени, указанного в переменной `PICODATA_INTERNAL_ON_SHUTDOWN_TIMEOUT`.
+
+Команда `cargo pike stop` также использует собственный timeout ожидания завершения процесса. Он задается через опцию `--timeout`. Если процесс не завершится в течение указанного времени, ему будет отправлен `SIGKILL`.
+
+Например:
+
+```bash
+cargo pike stop --data-dir ./tmp --signal SIGTERM --timeout 10
+```
+
 #### Доступные опции
 
 - `--data-dir <DATA_DIR>` - Путь к директории хранения файлов кластера. Значение по умолчанию: `./tmp`
 - `--plugin-path` - Путь до директории **проекта** плагина. Значение по умолчанию: `./`
 - `--instance-name <INSTANCE_NAME>` - Название инстанса Пикодаты. По умолчанию игнорируется.
+- `--signal <SIGNAL>` - Unix-сигнал, который будет отправлен процессам. По умолчанию: `SIGKILL`.
+- `--timeout <TIMEOUT_SECS>` - timeout ожидания завершения процесса. По умолчанию: `30 секунд`.
 
 ### `enter`
 

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -2,12 +2,21 @@ use crate::commands::lib::{get_active_socket_path, get_cluster_dir};
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use derive_builder::Builder;
-use log::info;
+use log::{info, warn};
+use nix::errno::Errno;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
+use procfs::process::{ProcState, Process};
 use std::fs::{self};
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+// Default signal sent by unix kill command during `pike stop` command.
+pub const DEFAULT_STOP_SIGNAL: Signal = Signal::SIGKILL;
+// Default timeout for graceful process shutdown.
+pub const DEFAULT_PROCESS_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Builder)]
 pub struct Params {
@@ -17,6 +26,10 @@ pub struct Params {
     plugin_path: PathBuf,
     #[builder(default)]
     instance_name: Option<String>,
+    #[builder(default = DEFAULT_STOP_SIGNAL)]
+    signal: Signal,
+    #[builder(default = DEFAULT_PROCESS_SHUTDOWN_TIMEOUT)]
+    timeout: Duration,
 }
 
 pub fn cmd(params: &Params) -> Result<()> {
@@ -105,7 +118,7 @@ fn stop_instance(params: &Params, instance_dir: &Path) -> Result<()> {
         return Ok(());
     }
 
-    if let Err(e) = kill(pid, Signal::SIGKILL) {
+    if let Err(e) = send_signal_and_wait(pid, params.signal, params.timeout) {
         bail!("failed to stop picodata instance with PID {pid}. Error: {e}");
     }
 
@@ -132,4 +145,51 @@ fn read_pid_from_file(pid_file_path: &Path) -> Result<Pid> {
     assert!(pid > 0);
 
     Ok(Pid::from_raw(pid))
+}
+
+/// Send signal to process and wait until it exits.
+///
+/// If the process does not terminate within the specified timeout,
+/// SIGKILL is sent as a fallback.
+fn send_signal_and_wait(pid: Pid, signal: Signal, timeout: Duration) -> anyhow::Result<()> {
+    kill(pid, signal)?;
+
+    let Ok(process) = Process::new(pid.into()) else {
+        // Process doesn't exist or we can't read /proc.
+        return Ok(());
+    };
+
+    let start = Instant::now();
+    let delay = Duration::from_millis(100);
+
+    while start.elapsed() < timeout {
+        sleep(delay);
+
+        match kill(pid, None) {
+            Err(Errno::ESRCH) => {
+                // Process no longer exists.
+                return Ok(());
+            }
+            Err(err) => bail!(err),
+            Ok(()) => {}
+        }
+
+        let Ok(state) = process.stat().and_then(|s| s.state()) else {
+            // We can't check process state or
+            // there is not such process in /proc.
+            return Ok(());
+        };
+
+        if state == ProcState::Zombie {
+            // Process is terminated, but not
+            // reaped by parent.
+            return Ok(());
+        }
+    }
+
+    warn!("Process {pid} did not terminate within {timeout:?}. Sending SIGKILL...");
+
+    kill(pid, Signal::SIGKILL)?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,13 @@
+use crate::commands::{
+    ride,
+    stop::{DEFAULT_PROCESS_SHUTDOWN_TIMEOUT, DEFAULT_STOP_SIGNAL},
+};
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
-use nix::unistd::{fork, ForkResult};
+use nix::{
+    sys::signal::Signal,
+    unistd::{fork, ForkResult},
+};
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -8,8 +15,6 @@ use std::{
     time::Duration,
 };
 use toml_edit::{DocumentMut, Item, Value};
-
-use crate::commands::ride;
 
 mod commands;
 mod healthcheck;
@@ -153,6 +158,23 @@ enum Command {
         /// will stop all instances in the cluster.
         #[arg(long, value_name = "INSTANCE_NAME", default_value = None)]
         instance_name: Option<String>,
+        /// Signal used to stop the cluster instances.
+        #[arg(
+            long,
+            value_name = "SIGNAL", 
+            default_value_t = DEFAULT_STOP_SIGNAL,
+            help = "Unix signal (e.g. SIGTERM, SIGKILL, SIGINT)"
+        )]
+        signal: Signal,
+        /// Graceful shutdown timeout used to wait for process termination
+        /// after sending the signal.
+        #[arg(
+            long,
+            value_name = "TIMEOUT_SECS",
+            default_value_t = DEFAULT_PROCESS_SHUTDOWN_TIMEOUT.as_secs(),
+            help = "Graceful shutdown timeout in seconds"
+        )]
+        timeout: u64,
     },
     /// Remove all data files of previous cluster run
     Clean {
@@ -431,14 +453,19 @@ fn main() -> Result<()> {
             data_dir,
             plugin_path,
             instance_name,
+            signal,
+            timeout,
         } => {
             is_required_path_exists(&plugin_path, &data_dir, CARING_PIKE, 1);
 
             run_child_killer();
+            let timeout = Duration::from_secs(timeout);
             let params = commands::stop::ParamsBuilder::default()
                 .data_dir(data_dir)
                 .plugin_path(plugin_path)
                 .instance_name(instance_name)
+                .signal(signal)
+                .timeout(timeout)
                 .build()
                 .unwrap();
             commands::stop::cmd(&params).context("failed to execute \"stop\" command")?;

--- a/tests/stop.rs
+++ b/tests/stop.rs
@@ -11,25 +11,19 @@ use std::{
 use crate::helpers::is_instance_running;
 
 const TOTAL_INSTANCES: i32 = 4;
+const CLUSTER_STOP_TIMEOUT: Duration = Duration::from_secs(60);
+const CLUSTER_START_TIMEOUT: Duration = Duration::from_secs(120);
 
-#[test]
-fn test_pike_stop() {
-    let _cluster_handle = run_cluster(
-        Duration::from_secs(120),
-        TOTAL_INSTANCES,
-        CmdArguments::default(),
-    )
-    .unwrap();
-
-    // Stop picodata cluster
-    exec_pike(["stop", "--plugin-path", PLUGIN_NAME]);
-
+fn assert_cluster_stopped(timeout: Duration) {
     let start = Instant::now();
-    while Instant::now().duration_since(start) < Duration::from_secs(60) {
+    let delay = Duration::from_millis(200);
+
+    while Instant::now().duration_since(start) < timeout {
         // Search for PID's of picodata instances and check their liveness
         let mut cluster_stopped = true;
-        for instance_dir in fs::read_dir(Path::new(PLUGIN_DIR).join("tmp").join("cluster")).unwrap()
-        {
+        let cluster_dir = Path::new(PLUGIN_DIR).join("tmp").join("cluster");
+
+        for instance_dir in fs::read_dir(cluster_dir).unwrap() {
             // Check if proccess of picodata is still running
             if is_instance_running(&instance_dir.unwrap().path()) {
                 cluster_stopped = false;
@@ -41,12 +35,66 @@ fn test_pike_stop() {
             return;
         }
 
-        thread::sleep(Duration::from_secs(1));
+        thread::sleep(delay);
     }
 
     panic!(
         "Timeouted while trying to stop cluster, processes with associated PID's are still running"
     );
+}
+
+#[test]
+fn test_pike_stop_default() {
+    let _cluster_handle = run_cluster(
+        CLUSTER_START_TIMEOUT,
+        TOTAL_INSTANCES,
+        CmdArguments::default(),
+    )
+    .unwrap();
+
+    // Stop picodata cluster
+    exec_pike(["stop", "--plugin-path", PLUGIN_NAME]);
+
+    assert_cluster_stopped(CLUSTER_STOP_TIMEOUT);
+}
+
+#[test]
+fn test_pike_stop_daemon_cluster() {
+    let cmd_args = CmdArguments {
+        run_args: ["--daemon"].iter().map(|&s| s.into()).collect(),
+        ..Default::default()
+    };
+    let _cluster_handle = run_cluster(CLUSTER_START_TIMEOUT, TOTAL_INSTANCES, cmd_args)
+        .expect("Failed to start cluster");
+
+    // Stop picodata cluster
+    exec_pike(["stop", "--plugin-path", PLUGIN_NAME]);
+
+    assert_cluster_stopped(CLUSTER_STOP_TIMEOUT);
+}
+
+#[test]
+fn test_pike_stop_sigterm_with_timeout() {
+    let _cluster_handle = run_cluster(
+        CLUSTER_START_TIMEOUT,
+        TOTAL_INSTANCES,
+        CmdArguments::default(),
+    )
+    .expect("Failed to start cluster");
+
+    // Stop picodata cluster
+    exec_pike([
+        "stop",
+        "--signal",
+        "SIGTERM",
+        "--timeout",
+        "5",
+        "--plugin-path",
+        PLUGIN_NAME,
+    ]);
+
+    // A bit more than specified in --timeout.
+    assert_cluster_stopped(Duration::from_secs(10));
 }
 
 #[test]


### PR DESCRIPTION
Add `--signal` option to the `stop` command to allow sending a custom Unix signal to cluster instances during shutdown.

To control the graceful shutdown timeout, the `--timeout` flag was added.
Use it to limit the maximum time in seconds allowed for cluster shutdown.

By default, `SIGKILL` is used and timeout is equal to 30s.

Closes #340