### PR TITLE
fix: kill picodata process before waiting in Drop

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -653,6 +653,10 @@ impl Drop for PicodataInstance {
             return;
         }
 
+        // Send kill to avoid infinite
+        // waiting of blocking processes.
+        let _ = self.child.kill();
+
         self.child
             .wait()
             .expect("Failed to wait for picodata instance");


### PR DESCRIPTION
Previously Drop only called wait(), which blocked indefinitely if the instance did not exit on its own. Now Drop sends a kill signal before waiting for process termination.