### PR TITLE
fix: do not treat readiness HTTP 503 as error

### DIFF
--- a/src/healthcheck/api.rs
+++ b/src/healthcheck/api.rs
@@ -111,6 +111,7 @@ fn build_client() -> ureq::Agent {
                 .build(),
         )
         .timeout_global(Some(REQUEST_TIMEOUT))
+        .http_status_as_error(false)
         .build()
         .into()
 }


### PR DESCRIPTION
Any status code returned from readiness endpoint is fine and should not be converted into error.

Disable it in HTTP client.