### PR TITLE
fix: return false for non-200 responses and probe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Make the HTTP probe check infallible. It now returns `false` unless the HTTP status code is 200. [#365](https://github.com/picodata/pike/issues/365)
+
 ## [5.3.2]
 
 ### Changed

--- a/src/commands/run/readiness.rs
+++ b/src/commands/run/readiness.rs
@@ -38,7 +38,7 @@ pub(super) fn wait_instances_ready(instances: &[PicodataInstance]) -> Result<()>
         let ready_count = instances
             .iter()
             .map(api::is_instance_ready)
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Vec<_>>()
             .into_iter()
             .filter(|&ready| ready)
             .count();

--- a/src/healthcheck/api.rs
+++ b/src/healthcheck/api.rs
@@ -2,6 +2,7 @@
 
 use crate::commands::run::PicodataInstance;
 use anyhow::{bail, Result};
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -127,11 +128,16 @@ fn check_instance_probe(
     http_client: &ureq::Agent,
     instance: &PicodataInstance,
     probe: &Probe,
-) -> Result<bool> {
+) -> bool {
     let url = build_probe_url(instance, probe);
-    let response = http_client.get(url).call()?;
 
-    Ok(response.status().is_success())
+    match http_client.get(&url).call() {
+        Ok(response) => response.status().is_success(),
+        Err(err) => {
+            debug!("HTTP GET to `{url}` returned an error: {err}");
+            false
+        }
+    }
 }
 
 /// Authenticates against `/api/v1/session` and returns JWT tokens.
@@ -171,10 +177,10 @@ pub fn get_health_status(instance: &PicodataInstance) -> Result<HealthStatus> {
 ///
 /// Returns "true" if both returned `HTTP_OK`.
 ///
-pub fn is_instance_ready(instance: &PicodataInstance) -> Result<bool> {
+#[must_use]
+pub fn is_instance_ready(instance: &PicodataInstance) -> bool {
     let http_client = build_client();
     let check_probe = |p| check_instance_probe(&http_client, instance, p);
-    let is_ready = check_probe(&Probe::Startup)? && check_probe(&Probe::Readiness)?;
 
-    Ok(is_ready)
+    check_probe(&Probe::Startup) && check_probe(&Probe::Readiness)
 }


### PR DESCRIPTION
Make HTTP probe checks resilient to request failures.

The probe now returns false for any request error and for all HTTP responses with a status code other than 200.

Closes #365 